### PR TITLE
Edited Dashboard, Personal Stats, Settings

### DIFF
--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -6,6 +6,7 @@ import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:csv_reader/csv_reader.dart';
 import 'package:LessApp/styles.dart';
 import 'dart:math';
+import 'package:intl/intl.dart';
 
 class DashboardPage extends StatefulWidget{
   @override
@@ -14,7 +15,14 @@ class DashboardPage extends StatefulWidget{
 
 class DashboardPageState extends State<DashboardPage> {
 
-  String selectedState = DashboardPageState.stateSelector(0.10, 0.50);
+  NumberFormat nf = NumberFormat("##0.00", "en_US");
+
+  double wasteThisWeek = 21.23;
+  double areaAverageThisWeek = 73.57;
+
+  double recyclablesThisWeek = 7.22;
+  double areaAverageRecyclablesThisWeek = 8.93;
+
   double sizeRelativeVisual = 1.0;
 
   static String stateSelector(double a, double b) {
@@ -168,7 +176,7 @@ class DashboardPageState extends State<DashboardPage> {
                                           )
                                       ),
                                       Expanded(
-                                          child: Text("0.67kg",
+                                          child: Text(nf.format(wasteThisWeek) + "kg",
                                             textAlign: TextAlign.center,
                                             style: TextStyle(
                                               fontSize: 25,
@@ -194,7 +202,7 @@ class DashboardPageState extends State<DashboardPage> {
                                           )
                                       ),
                                       Expanded(
-                                          child: Text("0.51kg",
+                                          child: Text(nf.format(areaAverageThisWeek) + "kg",
                                             textAlign: TextAlign.center,
                                             style: TextStyle(
                                               fontSize: 25,
@@ -230,7 +238,7 @@ class DashboardPageState extends State<DashboardPage> {
                                           )
                                       ),
                                       Expanded(
-                                          child: Text("0.41kg",
+                                          child: Text(nf.format(recyclablesThisWeek) + "kg",
                                             textAlign: TextAlign.center,
                                             style: TextStyle(
                                               fontSize: 25,
@@ -245,7 +253,6 @@ class DashboardPageState extends State<DashboardPage> {
                             Expanded(
                                 child: Column(
                                     children: <Widget>[
-
                                       Expanded(
                                           child: Text("Tembusu average this week:",
                                               style: TextStyle(
@@ -255,7 +262,7 @@ class DashboardPageState extends State<DashboardPage> {
                                               textAlign: TextAlign.center)
                                       ),
                                       Expanded(
-                                          child: Text("0.50kg",
+                                          child: Text(nf.format(areaAverageRecyclablesThisWeek) + "kg",
                                               style: TextStyle(
                                                 fontSize: 25,
                                                 fontWeight: FontWeight.bold,
@@ -282,7 +289,7 @@ class DashboardPageState extends State<DashboardPage> {
                           child: PageView(
                             controller: _controller2,
                             children: [
-                              trashBin(selectedState),
+                              trashBin(stateSelector(this.wasteThisWeek, this.areaAverageThisWeek)),
                               Image.asset('assets/recyclingIsland.png'),
                             ],
                             key: _keyVisual,
@@ -312,7 +319,7 @@ class DashboardPageState extends State<DashboardPage> {
                           height: 15,
                         ),
                         Container(
-                          child: selectionDots(context, selectedState)
+                          child: selectionDots(context, stateSelector(this.wasteThisWeek, this.areaAverageThisWeek))
                         ),
                         SizedBox(
                           height: 15,

--- a/lib/history.dart
+++ b/lib/history.dart
@@ -36,7 +36,6 @@ class HistoryPageState extends  State<HistoryPage> {
           elevation: 0,
         ),
 
-        //Styles.CommonHeader("Personal Statistics", FontWeight.bold, Colors.white),),
         body: Container(
           alignment: Alignment.center,
           color: Colors.white,
@@ -67,7 +66,6 @@ class HistoryPageState extends  State<HistoryPage> {
                                _typeChosen[i] = false;
                              }
                            }
-
                            _selectedType = newValue;
                          });
                       },
@@ -96,7 +94,6 @@ class HistoryPageState extends  State<HistoryPage> {
                               _trendChosen[i] = false;
                             }
                           }
-
                           _selectedTrend = newValue;
                         });
                       },

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -25,7 +25,7 @@ class HomePageState extends State<HomePage> {
     new PersonalStatsPage(),
     new DashboardPage(),
     new LeaderboardPage(),
-    new SettingsPage()
+    new SettingsPage(),
     //new DebugPage(),
   ];
 
@@ -62,12 +62,17 @@ class HomePageState extends State<HomePage> {
             icon: Icon(Icons.leaderboard),
             title: Text('Leaderboard'),
           ),
-
-
           BottomNavigationBarItem(
             icon: Icon(Icons.settings),
             title: Text('Setting'),
           ),
+
+          /*
+          BottomNavigationBarItem(
+            icon: Icon(Icons.warning),
+            title: Text('Debug'),
+          ),
+          */
 
 
         ],

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -16,37 +16,51 @@ class SettingsPageState extends State<SettingsPage>{
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: Styles.MainStatsPageHeader("Settings", FontWeight.bold, Colors.black),
       body: SettingsList(
+        backgroundColor: Colors.white,
         sections: [
           SettingsSection(
             title: 'Account',
             tiles: [
               SettingsTile(
                 title: 'Change Password ',
-                leading: Icon(Icons.language),
+                leading: Icon(Icons.lock_outlined),
                 onPressed: (BuildContext context) {},
               ),
 
               SettingsTile(
                 title: 'Sign Out',
-                leading: Icon(Icons.language),
+                leading: Icon(Icons.logout),
                 onPressed: (BuildContext context) {},
               ),
             ],
           ),
 
           SettingsSection(
-            title: 'Misc',
+            title: 'Miscellaneous ',
             tiles: [
+
               SettingsTile(
-                title: 'Terms of Services',
-                leading: Icon(Icons.language),
+                title: 'About Us',
+                leading: Icon(Icons.info_outlined),
+                onPressed: (BuildContext context) {},
+              ),
+
+              SettingsTile(
+                title: 'Contact Us',
+                leading: Icon(Icons.mail_outlined),
                 onPressed: (BuildContext context) {},
               ),
               SettingsTile(
-                title: 'About Us',
-                leading: Icon(Icons.language),
+                title: 'Terms of Services',
+                leading: Icon(Icons.article_outlined),
+                onPressed: (BuildContext context) {},
+              ),
+              SettingsTile(
+                title: 'Licences',
+                leading: Icon(Icons.copyright),
                 onPressed: (BuildContext context) {},
               ),
             ],


### PR DESCRIPTION
Dashboard
- edited dashboard code to remove magic literals used in text for general & recyclables' week amount and tembusu average

Personal Stats
- included personal weekly average line implementation that moves based on weekly average
- area weekly average has similar implementation but since we do not have a separate distinction between personal and area currently, the area weekly average line is not implemented yet.

Settings
- changed background colour to white
- edited icons to correspond with option
- added extra options

Home
- reinstated DebugPage code for debugging (has been commented out)