### PR TITLE
Replaced Data retrieval code

### DIFF
--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:http/http.dart' as http;
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:csv_reader/csv_reader.dart';
 import 'package:LessApp/styles.dart';
 import 'dart:math';
 import 'package:intl/intl.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:async/async.dart';
 
 class DashboardPage extends StatefulWidget{
   @override
@@ -25,7 +27,77 @@ class DashboardPageState extends State<DashboardPage> {
 
   double sizeRelativeVisual = 1.0;
 
+
+  final df3 = DateFormat.yMMMd();
+  final dfFilter = DateFormat("yyyy-MM-dd");
+  AsyncMemoizer _memoizer;
+  int userID = 1234;
+  List list = List();
+  Map map = Map();
+
+  _fetchData(String party, String type) async {
+    return this._memoizer.runOnce(() async {
+      String link;
+      if (party == "self") {
+        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${userID.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
+      } else {
+        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
+      }
+
+      final response = await http.get(link, headers: {"x-api-key": "YUgOYw37Yl5tmymEUGG3qaIfVdmten3S1YLAK8dI"});
+      if (response.statusCode == 200) {
+        map = json.decode(response.body) as Map;
+        list = map["data"];
+      } else {
+        throw Exception('Failed to load data');
+      }
+    });
+  }
+
+  Widget _buildStats(String party, String type) {
+    _fetchData(party, type);
+    var now = new DateTime.now();
+    List newList = list.where((entry) => DateTime.parse(dfFilter.format(DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000)).toString())
+        .isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
+        .toList();
+
+    double averageValue = newList.fold(0, (current, entry) => current + entry["weight"]) / 7.0;
+
+    setState(() {
+      if (type == "general") {
+        if (party == "self") {
+          wasteThisWeek = averageValue;
+        } else {
+          areaAverageThisWeek = averageValue;
+        }
+      } else {
+        if (party == "self") {
+          recyclablesThisWeek = averageValue;
+        } else {
+          areaAverageRecyclablesThisWeek = averageValue;
+        }
+      }
+    });
+
+    return Expanded(
+        child: Text(nf.format(averageValue) + "kg",
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 25,
+            fontWeight: FontWeight.bold,
+          ),
+        )
+    );
+  }
+
+
+
+
   static String stateSelector(double a, double b) {
+    if (b == 0) {
+      return "rubbishEmpty";
+    }
+
     double percFill = (a/b)*100;
     if (percFill < 50.0) {
       return "rubbishEmpty";
@@ -66,6 +138,7 @@ class DashboardPageState extends State<DashboardPage> {
   @override
   void initState() {
     super.initState();
+    _memoizer = AsyncMemoizer();
     _controller1 = PageController(
       initialPage: 0,
       viewportFraction: 1
@@ -160,6 +233,8 @@ class DashboardPageState extends State<DashboardPage> {
                   child: PageView(
                     controller: _controller1,
                     children: [
+
+                      //General waste page
                       Column(
                           children: <Widget>[
                             // This first expanded contains USER WEEKLY TOTAL
@@ -175,15 +250,7 @@ class DashboardPageState extends State<DashboardPage> {
                                             ),
                                           )
                                       ),
-                                      Expanded(
-                                          child: Text(nf.format(wasteThisWeek) + "kg",
-                                            textAlign: TextAlign.center,
-                                            style: TextStyle(
-                                              fontSize: 25,
-                                              fontWeight: FontWeight.bold,
-                                            ),
-                                          )
-                                      )
+                                      _buildStats("self", "general"),
                                     ]
                                 )
                             ),
@@ -201,22 +268,14 @@ class DashboardPageState extends State<DashboardPage> {
                                             ),
                                           )
                                       ),
-                                      Expanded(
-                                          child: Text(nf.format(areaAverageThisWeek) + "kg",
-                                            textAlign: TextAlign.center,
-                                            style: TextStyle(
-                                              fontSize: 25,
-                                              fontWeight: FontWeight.bold,
-                                            ),
-                                          )
-                                      )
+                                      _buildStats("tembusu", "general"),
                                     ]
                                 )
                             )
                           ]
                       ),
 
-
+                      //Recyclables waste page
                       Column(
                           children: <Widget>[
                             SizedBox(
@@ -237,18 +296,11 @@ class DashboardPageState extends State<DashboardPage> {
                                             ),
                                           )
                                       ),
-                                      Expanded(
-                                          child: Text(nf.format(recyclablesThisWeek) + "kg",
-                                            textAlign: TextAlign.center,
-                                            style: TextStyle(
-                                              fontSize: 25,
-                                              fontWeight: FontWeight.bold,
-                                            ),
-                                          )
-                                      )
+                                      _buildStats("self", "all"),
                                     ]
                                 )
                             ),
+
                             // This second expanded contains TEMBUSU WEEKLY TOTAL AVERAGE
                             Expanded(
                                 child: Column(
@@ -261,14 +313,7 @@ class DashboardPageState extends State<DashboardPage> {
                                               ),
                                               textAlign: TextAlign.center)
                                       ),
-                                      Expanded(
-                                          child: Text(nf.format(areaAverageRecyclablesThisWeek) + "kg",
-                                              style: TextStyle(
-                                                fontSize: 25,
-                                                fontWeight: FontWeight.bold,
-                                              ),
-                                              textAlign: TextAlign.center)
-                                      )
+                                      _buildStats("tembusu", "all"),
                                     ]
                                 )
                             ),
@@ -279,8 +324,8 @@ class DashboardPageState extends State<DashboardPage> {
 
               ),
 
-              // The second expanded is for the CHANGING VISUAL
 
+              // The second expanded is for the CHANGING VISUAL
               Expanded(
                   child: Container(
                       child: AspectRatio(
@@ -324,6 +369,7 @@ class DashboardPageState extends State<DashboardPage> {
                         SizedBox(
                           height: 15,
                         ),
+
                   Container(
                       alignment: Alignment.center,
                       padding: new EdgeInsets.only(

--- a/lib/history.dart
+++ b/lib/history.dart
@@ -1,7 +1,12 @@
+import 'dart:convert';
+import 'package:async/async.dart';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:LessApp/styles.dart';
 import 'package:intl/intl.dart';
+import 'package:http/http.dart' as http;
 
 class HistoryPage extends StatefulWidget{
   @override
@@ -10,7 +15,10 @@ class HistoryPage extends StatefulWidget{
 
 class HistoryPageState extends  State<HistoryPage> {
 
+  AsyncMemoizer _memoizer;
+
   NumberFormat nf = NumberFormat("###.00", "en_US");
+
   String _selectedType = "General";
   String _selectedTrend = "Week";
 
@@ -19,9 +27,96 @@ class HistoryPageState extends  State<HistoryPage> {
 
   List<bool> _trendChosen = [true, false, false];
   List<String> _trendList = ["Week", "Month", "All Time"];
+  List list = List();
+  Map map = Map();
+
+  final df = new DateFormat('dd-MM-yyyy hh:mm a');
+  final df2 = new DateFormat(DateFormat.YEAR_MONTH_DAY, 'en_US');
+  final df3 = DateFormat.yMMMd();
+  final df4 = new DateFormat('d MMM yyyy');
+  final df5 = new DateFormat('MMM');
+  final dfFilter = DateFormat("yyyy-MM-dd");
+  int userID = 1234;
+
+  @override
+  void initState() {
+    super.initState();
+    _memoizer = AsyncMemoizer();
+  }
+
+  _fetchData() async {
+    return this._memoizer.runOnce(() async {
+      String currentType;
+      if (_typeChosen[0]) {
+        currentType = "general";
+      } else {
+        currentType = "all";
+      }
+
+      String link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${userID.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${currentType}";
+
+      final response = await http.get(link, headers: {"x-api-key": "YUgOYw37Yl5tmymEUGG3qaIfVdmten3S1YLAK8dI"});
+      if (response.statusCode == 200) {
+        map = json.decode(response.body) as Map;
+        list = map["data"];
+      } else {
+        throw Exception('Failed to load data');
+      }
+    });
+  }
+
+  Widget _buildList() {
+
+    _fetchData();
+    var now = new DateTime.now();
+    List newList;
+
+    switch(_selectedTrend) {
+
+      //month's worth of data
+      case "Month": {
+        newList = list.where((entry)=> DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000).month == DateTime.now().month )
+            .toList();
+      }
+      break;
+
+      //all time data
+      case "All Time": {
+        newList = list;
+      }
+      break;
+
+      //week's worth of data
+      default: {
+        newList = list.where((entry) => DateTime.parse(dfFilter.format(DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000)).toString())
+            .isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
+            .toList();
+      }
+
+    }
+
+    return Expanded(
+        child: ListView.builder(
+          itemCount: newList.length,
+          reverse: true,
+          itemBuilder: (BuildContext context, int index) {
+            return ListTile(
+              contentPadding: EdgeInsets.all(10.0),
+              title: new Text(df4.format(DateTime.fromMillisecondsSinceEpoch(newList[index]["time"] * 1000)).toString()),
+              //title: new Text(DateTime.now().month.toString()),
+              subtitle: new Text(newList[index]["weight"].toString() + "kg"),
+            );
+            },
+        )
+    );
+  }
+
 
   @override
   Widget build(BuildContext context) {
+
+    //_fetchData();
+    //List filteredList = _chooseList(list, _selectedTrend);
 
     return Scaffold(
         appBar: AppBar(
@@ -100,10 +195,30 @@ class HistoryPageState extends  State<HistoryPage> {
                     ),
                   ],
                 ),
-
-
               ),
 
+              _buildList(),
+
+              /*
+               * the code causing too many calls
+              Expanded(
+                child: ListView.builder(
+                  itemCount: filteredList.length,
+                  reverse: true,
+                  itemBuilder: (BuildContext context, int index) {
+                    return ListTile(
+                      contentPadding: EdgeInsets.all(10.0),
+                      title: new Text(df3.format(DateTime.fromMillisecondsSinceEpoch(filteredList[index]["time"] * 1000)).toString()),
+                      subtitle: new Text(filteredList[index]["weight"].toString() + "kg"),
+                    );
+                  },
+                )
+              ),
+              */
+
+
+              /*
+               * Previous Implementation using Firestore
               StreamBuilder(
                 stream: Firestore
                     .instance
@@ -147,6 +262,9 @@ class HistoryPageState extends  State<HistoryPage> {
                   );
                 },
               )
+              */
+
+
             ],
           )
         )

--- a/lib/massentry.dart
+++ b/lib/massentry.dart
@@ -4,14 +4,15 @@ import 'package:intl/intl.dart';
 class formattedWeekEntry {
   double mass;
   String day;
-  formattedWeekEntry(this.mass,this.day);
+  formattedWeekEntry(this.mass, this.day);
 }
 
 class MassEntry {
 
   double mass;
   final DateTime dateTimeValue;
-  final String timestamp,shortenedTime,day,month,year;
+  final String timestamp, shortenedTime, day, month, year;
+
   MassEntry (
       this.mass,
       this.timestamp,

--- a/lib/personal-stats.dart
+++ b/lib/personal-stats.dart
@@ -1,5 +1,4 @@
 import 'dart:ui';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -9,6 +8,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import 'package:LessApp/styles.dart';
 import 'package:LessApp/dashboard.dart';
+import 'dart:convert';
+import 'package:async/async.dart';
+import 'package:http/http.dart' as http;
 
 class PersonalStatsPage extends StatefulWidget{
   @override
@@ -29,10 +31,70 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
   List<charts.Series<MassEntry, DateTime>> _timeChartData;
   List<MassEntry> myData, massEntryDay;
   static int pageCounter = 15001;
-  double personalWeekAverage = 0.00;
-  double areaWeekAverage = 0.00;
 
-  NumberFormat nf = NumberFormat("###.00", "en_US");
+
+  double personalWeekAverageGeneral = 0.00;
+  double areaWeekAverageGeneral = 0.00;
+
+  double personalWeekAverageAll = 0.00;
+  double areaWeekAverageAll = 0.00;
+  double personalWeekAveragePlastic = 0.00;
+  double areaWeekAveragePlastic = 0.00;
+  double personalWeekAveragePaper = 0.00;
+  double areaWeekAveragePaper = 0.00;
+
+
+
+  AsyncMemoizer _memoizer;
+  NumberFormat nf = NumberFormat("#00.00", "en_US");
+  final df3 = DateFormat.yMMMd();
+  final dfFilter = DateFormat("yyyy-MM-dd");
+  int userID = 1234;
+  List list = List();
+  Map map = Map();
+
+  @override
+  void initState() {
+    super.initState();
+    _memoizer = AsyncMemoizer();
+  }
+
+  _fetchData(String party, String type) async {
+
+    return this._memoizer.runOnce(() async {
+
+      int id = 1234;
+
+      String currentType;
+      if (isSelectedTypeAll[0]) {
+        currentType = "general";
+      } else {
+        if (isSelectedType[0]) {
+          currentType = "all";
+        } else if (isSelectedType[1]) {
+          currentType = "paper";
+        } else {
+          currentType = "plastic";
+        }
+      }
+
+      String link;
+      if (party == "self") {
+        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${id.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${currentType}";
+      } else {
+        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${currentType}";
+      }
+
+      final response = await http.get(link, headers: {"x-api-key": "YUgOYw37Yl5tmymEUGG3qaIfVdmten3S1YLAK8dI"});
+      if (response.statusCode == 200) {
+        map = json.decode(response.body) as Map;
+        list = map["data"];
+      } else {
+        throw Exception('Failed to load data');
+      }
+    });
+  }
+
 
   _generateData(myData) {
     _seriesBarData = List<charts.Series<MassEntry, String>>();
@@ -334,26 +396,30 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
             ),
 
             //today trash textbox
-            isSelectedTypeAll[0] ? Container(
+            Container(
               decoration: BoxDecoration(
                 color:  isSelectedTypeAll[0] ? colorPalette[1]: colorPalette[0],
                 borderRadius: BorderRadius.circular(5),
               ),
-              height: 115,
+              height: 90,
               width: MediaQuery.of(context).size.width/1.05,
               padding: EdgeInsets.all(10),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
+
                   Text("Today you threw away",
                     style: TextStyle(
                       fontSize: 25,
                     ),
                   ),
 
+
                   SizedBox(
                       height:5
                   ),
+
+                  _buildStatsDailyInfo("self"),
 
               /*
               //for week's worth of trash thrown
@@ -391,7 +457,7 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
               ),
                   */
 
-
+                  /*
                   //for amount thrown today by user
                   StreamBuilder<QuerySnapshot>(
                     stream: Firestore.instance
@@ -428,17 +494,47 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
                         //print(jsonEncode(massEntry).toString());
                         double todayMass = massEntry.fold(0, (previousValue, element) => previousValue + element.mass);
                         double weeklyMass = weekData.fold(0, (previousValue, element) => previousValue + element.mass);
-                        personalWeekAverage = weeklyMass / 7.0;
+                        personalWeekAverageGeneral = weeklyMass / 7.0;
                         //return getPersonalWeekTotal("House_A");
                         return Styles.formatNumber(todayMass);
                       }
                     },
                   )
+                  */
 
                 ],
               ),
-            ) : new Container(),
+            ),
 
+            Container(
+              child:  Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+
+                  Container(
+                    child: Text("  Personal \n  Week Average: ",
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                      ),),
+                  ),
+                  _buildStatsWeekInfo("self", selectedType, Colors.purple),
+
+                  Container(
+                    child: Text("  Tembusu \n  Week Average: ",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                      ),),
+                  ),
+                  _buildStatsWeekInfo("self", selectedType, Colors.teal[600]),
+                ],
+              ),
+            ),
+
+
+            /*
             //today recyclables textbox
             isSelectedTypeAll[1] ? Container(
               decoration: BoxDecoration(
@@ -492,6 +588,7 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
               ),
                   */
 
+
                   StreamBuilder<QuerySnapshot>(
                     stream: Firestore.instance
                         .collection('houses')
@@ -520,17 +617,116 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
                       }
                     },
                   )
+
                 ],
               ),
             ) : new Container(),
+            */
 
 
             //build the graph
             isSelectedTypeAll[0] ? _buildBody(context) : new Container(),
+
     ]
     )));
   }//, String time
 
+
+  MassEntry massEntryGenerator(int time, int weight) {
+
+    final df4 = new DateFormat('d MMM yyyy');
+    final df5 = new DateFormat('MMM');
+
+    Map<String, dynamic> map = Map();
+
+    double mass = double.parse(weight.toString());
+    DateTime dateTimeValue = DateTime.fromMillisecondsSinceEpoch(time * 1000);
+    String timestamp = dateTimeValue.toIso8601String();
+    String shortenedTime = df4.format(dateTimeValue).toString();
+    String day = dateTimeValue.day.toString();
+    String month = df5.format(dateTimeValue).toString();
+    String year = dateTimeValue.year.toString();
+
+    return MassEntry(mass, timestamp, shortenedTime, dateTimeValue, day, month, year);
+  }
+
+  Widget _buildBody(BuildContext context) {
+
+    _fetchData("self", selectedType);
+    List<MassEntry> nextList = list.map((entry) => massEntryGenerator(entry["time"], entry["weight"])).toList();
+    return _chooseChart(context, nextList, selectedTime);
+  }
+
+  Widget _chooseChart(BuildContext context, List<MassEntry> massdata, String time) {
+
+    switch(time){
+      case "week":{
+
+        myData = massdata.where((i)=> DateTime.parse(i.timestamp).isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
+            .toList();
+        _generateWeeklyData(formatWeekdays(combineDays(myData)));
+        print(DateTime.now().weekday.toString());
+
+        return Expanded(
+          child: charts.BarChart(_weekSeriesBarData,
+            animate: true, behaviors: [
+              new charts.RangeAnnotation([
+                new charts.LineAnnotationSegment(
+                    personalWeekAverageGeneral, charts.RangeAnnotationAxisType.measure,
+                    color: charts.MaterialPalette.blue.shadeDefault),
+              ])
+            ],
+          ),
+        );
+      }
+      break;
+
+      case "month": {
+
+        myData = massdata.where((i)=> i.dateTimeValue.month == DateTime.now().month )
+            .toList();
+        _generateComDayData(fillInDays(combineDays(myData)));
+        return Expanded(
+          child: charts.BarChart(_seriesBarData,
+            animate: true,
+          ),
+        );
+      }
+      break;
+
+      case "allTime":{
+        myData = massdata;
+        _generateTimeChartData(fillInDays(combineDays(myData)));
+        return Expanded(
+          child: charts.TimeSeriesChart(_timeChartData,
+            animate: true,
+            defaultRenderer:
+            new charts.LineRendererConfig(includeArea: true, stacked: true),
+          ),
+        );
+      }
+      break;
+
+      default: {
+        //same as today
+        myData = massdata.where((i)=> i.shortenedTime == DateFormat('d MMM y').format(DateTime.now()).toString())
+            .toList();
+        _generateData(myData);
+
+        return Expanded(
+          child: charts.BarChart(_seriesBarData,
+            animate: true,),
+        );
+      }
+      break;
+    }
+  }
+
+
+
+
+
+  /*
   Widget _buildBody(BuildContext context) {
     return StreamBuilder<QuerySnapshot>(
       stream: Firestore.instance
@@ -551,35 +747,17 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
       },
     );
   }
-
-  /*
-  //new graph with data filtered to include type of trash thrown also
-  Widget _buildBody(BuildContext context) {
-    return StreamBuilder<QuerySnapshot>(
-      stream: Firestore.instance
-          .collection('houses')
-          .document("House_A")
-          .collection("RawData")
-          .snapshots(),
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) {
-          return CircularProgressIndicator();
-        } else {
-          List<MassEntry> massEntryRaw = snapshot.data.documents
-              .map((documentSnapshot) => MassEntry.fromMap(documentSnapshot.data))
-              .toList();
-          return _chooseChart(context, massEntryRaw, selectedTime, selectedType);
-          //return _chooseChart(context, massEntryRaw, time);
-        }
-      },
-    );
-  }
   */
+
 
   List<MassEntry> combineDays(List<MassEntry> rawdata){
     List<MassEntry> output = [];
+    if (rawdata.isEmpty) {
+      return rawdata;
+    }
 
-    for ( var i = 0; i <rawdata.length; i++){
+    for (var i = 0; i < rawdata.length; i++) {
+
       if (output.where((element) =>
           element.shortenedTime
               == rawdata[i].shortenedTime).isEmpty){
@@ -598,6 +776,10 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
   }
   
   List<MassEntry> fillInDays(List<MassEntry> rawdata) {
+    if (rawdata.isEmpty) {
+      return rawdata;
+    }
+
     var now = new DateTime.now();
     final firstEntryDate = rawdata[0].dateTimeValue;
     var timeFromFirstEntryInSeconds = now.difference(firstEntryDate);
@@ -634,89 +816,94 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
       formattedWeekEntry(0,"THU"),
       formattedWeekEntry(0,"FRI"),
       formattedWeekEntry(0,"SAT"),
-      formattedWeekEntry(0,"SUN")
+      formattedWeekEntry(0,"SUN"),
     ];
+
     int currentTime = DateTime.now().weekday;
-    for ( var i = currentTime; i >0; i--){
+
+    for ( var i = currentTime; i > 0; i--){
       var x = rawdata.where((element) =>
       element.dateTimeValue.weekday == i);
+
       if (x.isNotEmpty){
         output[i-1].mass = rawdata[rawdata.indexOf(x.toList()[0])].mass;
       }
-      
     }
-
-
-
     return output;
   }
 
-  Widget _chooseChart(BuildContext context, List<MassEntry> massdata, String time) {
-    switch(time){
-      case "week":{
+  Widget _buildStatsDailyInfo(String party) {
 
-        myData = massdata.where((i)=> DateTime.parse(i.timestamp).isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
-            .toList();
-        _generateWeeklyData(formatWeekdays(combineDays(myData)));
-        print(DateTime.now().weekday.toString());
-        return Expanded(
-          child: charts.BarChart(_weekSeriesBarData,
-            animate: true, behaviors: [
-              new charts.RangeAnnotation([
-                new charts.LineAnnotationSegment(
-                    personalWeekAverage, charts.RangeAnnotationAxisType.measure,
-                    //startLabel: "Your week average: " + nf.format(personalWeekAverage) + "kg",
-                    endLabel: "Your week average: " + nf.format(personalWeekAverage) + "kg",
-                    color: charts.MaterialPalette.gray.shade400),
-                //TODO: NEED TO ADD TEMBUSU'S WEEKLY AVERAGE. SIMILAR IMPLEMENTATION TO ABOVE.
-              ])
-            ],
+    _fetchData(party, selectedType);
+    var now = new DateTime.now();
+    List newList = list.map((entry) => massEntryGenerator(entry["time"], entry["weight"])).where((i)=> i.shortenedTime == DateFormat('d MMM y').format(DateTime.now()).toString())
+        .toList();
+
+    double totalValue = newList.fold(0, (current, entry) => current + entry["weight"]);
+
+    return Expanded(
+        child: Text(nf.format(totalValue) + "kg",
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 25,
+            fontWeight: FontWeight.bold,
           ),
-        );
-      }
-      break;
-
-      case "month":{
-        myData = massdata.where((i)=> i.dateTimeValue.month == DateTime.now().month )
-            .toList();
-        // myData = massdata.where((i)=> DateTime.parse(i.timestamp).isAfter(DateTime.now().subtract(Duration(days: 30)))  )
-        //     .toList();
-        _generateComDayData(fillInDays(combineDays(myData)));
-        return Expanded(
-          child: charts.BarChart(_seriesBarData,
-            animate: true,
-          ),
-        );
-      }
-      break;
-
-      case "allTime":{
-        myData = massdata;
-        _generateTimeChartData(fillInDays(combineDays(myData)));
-        return Expanded(
-          child: charts.TimeSeriesChart(_timeChartData,
-              animate: true,
-            defaultRenderer:
-                new charts.LineRendererConfig(includeArea: true, stacked: true),
-          ),
-        );
-      }
-      break;
-
-      default: {
-        //same as today
-        myData = massdata.where((i)=> i.shortenedTime == DateFormat('d MMM y').format(DateTime.now()).toString())
-            .toList();
-        _generateData(myData);
-        return Expanded(
-          child: charts.BarChart(_seriesBarData,
-            animate: true,),
-        );
-      }
-      break;
-    }
-
+        )
+    );
   }
+
+  Widget _buildStatsWeekInfo(String party, String type, Color color) {
+
+    _fetchData(party, selectedType);
+
+    var now = new DateTime.now();
+
+    List newList = list.where((entry) => DateTime.parse(dfFilter.format(DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000)).toString())
+        .isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
+        .toList();
+
+    double averageValue = newList.fold(0, (current, entry) => current + entry["weight"]) / 7.0;
+
+    setState(() {
+      if (type == "general") {
+        if (party == "self") {
+          personalWeekAverageGeneral = averageValue;
+        } else {
+          areaWeekAverageGeneral = averageValue;
+        }
+      } else if (type == "all") {
+        if (party == "self") {
+          personalWeekAverageAll = averageValue;
+        } else {
+          areaWeekAverageAll = averageValue;
+        }
+      } else if (type == "paper") {
+        if (party == "self") {
+          personalWeekAveragePaper = averageValue;
+        } else {
+          areaWeekAveragePaper = averageValue;
+        }
+      } else {
+        if (party == "self") {
+          personalWeekAveragePlastic = averageValue;
+        } else {
+          areaWeekAveragePlastic = averageValue;
+        }
+      }
+    });
+
+    return Expanded(
+        child: Text(nf.format(averageValue) + "kg",
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
+        )
+    );
+  }
+
 
 
 


### PR DESCRIPTION
- Commented out code that retrieves data from Firestore to be populated in App
- Included code that retrieves data from AWS using http get (standardised to be _fethdata(params, if any) for all .dart files)
- Added working filter feature for both leaderboard, history, and statistics page
- Amended dashboard code to be linked to data retrieved from AWS's http get JSON file

TODO (potentially):
- segregate individual persons data away from collective data to enable distinction between personal statistics and area statistics (eg personal week average trash thrown vs Tembusu's week average amount of trash thrown)
- change colour of lines in statistics page (if approved and team is fine with the amount of information on screen). => also need to amend code to change line **colour** and **position**.


Merry Christmas!
