### PR TITLE
updates to all sections except dashboard

### DIFF
--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -31,7 +31,6 @@ class DashboardPageState extends State<DashboardPage> {
 
   final df3 = DateFormat.yMMMd();
   final dfFilter = DateFormat("yyyy-MM-dd");
-  int userID = 1234;
   List list = List();
   Map map = Map();
   AsyncMemoizer _memoizer;
@@ -61,7 +60,7 @@ class DashboardPageState extends State<DashboardPage> {
     return this._memoizer.runOnce(() async {
       String link;
       if (party == "self") {
-        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${userID.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
+        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${WasteLessData.userID.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
       } else {
         link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
       }

--- a/lib/leaderboard.dart
+++ b/lib/leaderboard.dart
@@ -16,32 +16,31 @@ class LeaderboardPageState extends  State<LeaderboardPage> {
 
   NumberFormat nf = NumberFormat("###.00", "en_US");
 
-  String _selectedType = "General";
-  String _selectedTrend = "Week";
+  String _selectedType = "Select Type";
+  String _selectedTrend = "Select Trend";
 
-  List<bool> _typeChosen = [true, false];
-  List<String> _typeList = ["General", "Recyclables"];
+  List<bool> _typeChosen = [true, false, false];
+  List<String> _typeList = ["Select Type", "Trash", "Recyclables"];
 
-  List<bool> _trendChosen = [true, false, false];
-  List<String> _trendList = ["Week", "Month", "All Time"];
+  List<bool> _trendChosen = [true, false, false, false];
+  List<String> _trendList = ["Select Trend", "Week", "Month", "All Time"];
 
   List list = List();
   Map map = Map();
+
+  final dfFilter = DateFormat("yyyy-MM-dd");
+  final df3 = DateFormat('d MMM yyyy');
+
   AsyncMemoizer _memoizer;
   @override
   void initState() {
     _memoizer = AsyncMemoizer();
   }
 
-  final dfFilter = DateFormat("yyyy-MM-dd");
-  final df3 = DateFormat('d MMM yyyy');
-
-
-
   _fetchData() async {
     return this._memoizer.runOnce(() async {
       String currentType;
-      if (_typeChosen[0]) {
+      if (_typeChosen[1]) {
         currentType = "general";
       } else {
         currentType = "all";
@@ -64,11 +63,7 @@ class LeaderboardPageState extends  State<LeaderboardPage> {
 
   Widget _buildList() {
 
-    _fetchData();
-    //WasteLessData data = new WasteLessData();
-    //List retrievedList = data.getListHistoryAndLeaderboard(_selectedType);
-    //this.list = retrievedList;
-
+    //_fetchData();
 
     var now = new DateTime.now();
     List newList;
@@ -82,41 +77,77 @@ class LeaderboardPageState extends  State<LeaderboardPage> {
       }
       break;
 
-    //all time data
+      //all time data
       case "All Time": {
         newList = list;
       }
       break;
 
-    //week's worth of data
-      default: {
+      //week's worth of data
+      case "Week": {
         newList = list.where((entry) => DateTime.parse(dfFilter.format(DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000)).toString())
             .isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
             .toList();
       }
+      break;
 
+      default: {
+        newList = List();
+      }
     }
 
-    return Expanded(
-        child: ListView.builder(
-          itemCount: newList.length,
-          reverse: true,
-          itemBuilder: (BuildContext context, int index) {
-            return ListTile(
-              contentPadding: EdgeInsets.all(10.0),
-              title: new Text(df3.format(DateTime.fromMillisecondsSinceEpoch(newList[index]["time"] * 1000)).toString()),
-              subtitle: new Text(newList[index]["weight"].toString() + "kg"),
-            );
-          },
-        )
-    );
+    newList = new List.from(newList.reversed);
+
+    if (_typeChosen[0] || _trendChosen[0]) {
+      return Expanded(
+        child: Center(
+          child: Text("Please select your desired \nType and Trend",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 25,
+              //fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      );
+    }
+
+    else if (newList.length == 0) {
+      return Expanded(
+        child: Center(
+          child: Text("NO DATA",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 25,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      );
+    } else {
+      return Expanded(
+          child: ListView.builder(
+            itemCount: newList.length,
+            itemBuilder: (BuildContext context, int index) {
+              return Container(
+                  color:   _typeChosen[1] ? ((index % 2 == 0) ? Colors.brown[100] : Colors.white10) : ((index % 2 == 0) ? Colors.lightGreenAccent : Colors.white10),
+                  child: ListTile(
+                    contentPadding: EdgeInsets.all(10.0),
+                    title: new Text(df3.format(DateTime.fromMillisecondsSinceEpoch(newList[index]["time"] * 1000)).toString()),
+                    //title: new Text(DateTime.now().month.toString()),
+                    subtitle: new Text(newList[index]["weight"].toString() + "kg"),
+                  )
+              );
+            },
+          )
+      );
+    }
   }
 
   @override
   Widget build(BuildContext context) {
 
-    //_fetchData();
-    //List filteredList = _chooseList(list, _selectedTrend);
+    _fetchData();
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/login/login.dart
+++ b/lib/login/login.dart
@@ -80,7 +80,6 @@ class LoginState extends State<Login> {
 
           ], ),
       ),
-
     );
   }
 

--- a/lib/personal-stats.dart
+++ b/lib/personal-stats.dart
@@ -19,20 +19,22 @@ class PersonalStatsPage extends StatefulWidget{
 }
 
 class PersonalStatsPageState extends State<PersonalStatsPage>{
-  final title = ["Personal Trash Stats", "Personal Recycling Stats"];
+
   final now = DateTime.now();
   String selectedTime = "week";
   String selectedType = "general";
   List<bool> isSelectedTrend = [true, false, false];
   List<bool> isSelectedType = [false, true, false];
+
   List<bool> isSelectedTypeAll = [true, false];
+  List<String> title = ["Personal Trash Stats", "Personal Recycling Stats"];
+
   List<Color> colorPalette = [Colors.lightGreen[200], Colors.brown[100]];
   List<charts.Series<MassEntry, String>> _seriesBarData;
   List<charts.Series<formattedWeekEntry, String>> _weekSeriesBarData;
   List<charts.Series<MassEntry, DateTime>> _timeChartData;
   List<MassEntry> myData, massEntryDay;
   static int pageCounter = 15001;
-
 
   double personalWeekAverageGeneral = 0.00;
   double areaWeekAverageGeneral = 0.00;
@@ -75,24 +77,10 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
 
     return this._memoizer.runOnce(() async {
 
-      int id = 1234;
-
-      String currentType;
-      if (isSelectedTypeAll[0]) {
-        currentType = "general";
-      } else {
-        if (isSelectedType[0]) {
-          currentType = "all";
-        } else if (isSelectedType[1]) {
-          currentType = "paper";
-        } else {
-          currentType = "plastic";
-        }
-      }
-
       String link;
+
       if (party == "self") {
-        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${id.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
+        link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste/${WasteLessData.userID.toString()}?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
       } else {
         link = "https://yt7s7vt6bi.execute-api.ap-southeast-1.amazonaws.com/dev/waste?aggregateBy=day&timeRangeStart=0&timeRangeEnd=1608364825&type=${type}";
       }
@@ -211,6 +199,84 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
     );
   }
 
+  Widget trendAverageBar() {
+    if (isSelectedTrend[0]) {
+      return Container(
+        decoration: BoxDecoration(
+          color: isSelectedTypeAll[0] ? colorPalette[1]: colorPalette[0],
+          //Colors.lightGreen[200],
+          borderRadius: BorderRadius.circular(5),
+        ),
+        height: 50,
+        width: MediaQuery.of(context).size.width/1.05,
+        padding: EdgeInsets.all(7),
+        child:  Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+
+            Container(
+              child: Text("Personal\nWeek Average: ",
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            _buildStatsInfo("self", selectedTime, selectedType, Colors.purple),
+
+            Container(
+              child: Text("Tembusu\nWeek Average: ",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            _buildStatsInfo("self", selectedTime, selectedType, Colors.teal.shade900),
+          ],
+        ),
+      );
+    } else {
+      return Container(
+        decoration: BoxDecoration(
+          color: isSelectedTypeAll[0] ? colorPalette[1]: colorPalette[0],
+          //Colors.lightGreen[200],
+          borderRadius: BorderRadius.circular(5),
+        ),
+        height: 50,
+        width: MediaQuery.of(context).size.width/1.05,
+        padding: EdgeInsets.all(7),
+        child:  Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+
+            Container(
+              child: Text("Personal\nMonth Average: ",
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            _buildStatsInfo("self", selectedType, selectedTime, Colors.purple),
+
+            Container(
+              child: Text("Tembusu\nMonth Average: ",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            _buildStatsInfo("self", selectedType, selectedTime, Colors.teal.shade900),
+          ],
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
 
@@ -218,8 +284,57 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
     bool allVisible = PersonalStatsPageState.pageCounter % 3 == 1;
     bool plasticVisible = PersonalStatsPageState.pageCounter % 3 == 2;
 
+    String currentTitle;
+    if (isSelectedTypeAll[0]) {
+      currentTitle = title[0];
+    } else {
+      currentTitle = title[1];
+    }
+
     return Scaffold(
-      appBar: Styles.MainStatsPageHeader(title[0], FontWeight.bold, Colors.black),
+      //appBar: Styles.MainStatsPageHeader(title[0], FontWeight.bold, Colors.black),
+      appBar: AppBar(
+        title: ButtonTheme(
+          minWidth: MediaQuery.of(context).size.width/1.05,
+          height: 10.0,
+          child: RaisedButton(
+            elevation: 10.0,
+            color: isSelectedTypeAll[0] ? colorPalette[1]: colorPalette[0],
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(15),
+              //side: BorderSide(color: Colors.white),
+            ),
+            padding: EdgeInsets.all(10.0),
+
+
+            child: Text(currentTitle,
+              style: TextStyle(
+                //fontWeight: FontWeight.bold,
+                color: Colors.black,
+                fontSize: 20,
+              ),
+            ),
+            onPressed: () {
+              setState(() {
+                for (int i = 0; i < isSelectedTypeAll.length; i++) {
+                  if (isSelectedTypeAll[i]) {
+                    isSelectedTypeAll[i] = false;
+                  } else {
+                    isSelectedTypeAll[i] = true;
+                  }
+                }
+              });
+            },
+          ),
+        ),
+
+        centerTitle: true,
+
+        backgroundColor: Colors.white,
+        elevation: 0,
+
+      ),
+
 
       body: Container(
         alignment: Alignment.center,
@@ -228,6 +343,7 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
         child: Column(
           children: <Widget>[
 
+            /*
             Container(
                 decoration: BoxDecoration(
                   color: isSelectedTypeAll[0] ? colorPalette[1]: colorPalette[0],
@@ -236,8 +352,9 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
                 height: 40,
                 width: MediaQuery.of(context).size.width/1.05,
                 padding: EdgeInsets.all(7),
-                child: Center(
+                child:
 
+                Center(
                   child: ToggleButtons(
                     renderBorder: false,
                     children: <Widget>[
@@ -276,9 +393,10 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
                     },
                     isSelected: isSelectedTypeAll,
                   ),
-
                 )
             ),
+
+            */
 
             isSelectedTypeAll[1] ? SizedBox(
               height: 10,
@@ -427,7 +545,6 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
                     ),
                   ),
 
-
                   SizedBox(
                       height:5
                   ),
@@ -519,33 +636,11 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
               ),
             ),
 
-            Container(
-              child:  Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: <Widget>[
-
-                  Container(
-                    child: Text("  Personal \n  Week Average: ",
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.bold,
-                      ),),
-                  ),
-                  _buildStatsWeekInfo("self", selectedType, Colors.purple),
-
-                  Container(
-                    child: Text("  Tembusu \n  Week Average: ",
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.bold,
-                      ),),
-                  ),
-                  _buildStatsWeekInfo("self", selectedType, Colors.teal[600]),
-                ],
-              ),
+            SizedBox(
+                height: 10,
             ),
 
+            (isSelectedTrend[0] || isSelectedTrend[1] ) ? trendAverageBar() : new Container(),
 
             /*
             //today recyclables textbox
@@ -870,6 +965,7 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
     //this.list = retrievedList;
 
     var now = new DateTime.now();
+
     List newList = list.map((entry) => massEntryGenerator(entry["time"], entry["weight"])).where((i)=> i.shortenedTime == DateFormat('d MMM y').format(DateTime.now()).toString())
         .toList();
 
@@ -886,7 +982,9 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
     );
   }
 
-  Widget _buildStatsWeekInfo(String party, String type, Color color) {
+  Widget _buildStatsInfo(String party, String trend, String type, Color color) {
+
+    var now = new DateTime.now();
 
     setState(() {
       if (isSelectedTypeAll[0]) {
@@ -902,17 +1000,26 @@ class PersonalStatsPageState extends State<PersonalStatsPage>{
       }
     });
 
-    //WasteLessData data = new WasteLessData();
-    //List retrievedList = data.getListDashboard(party, selectedType);
-    //this.list = retrievedList;
+    List newList;
+    double averageValue;
 
-    var now = new DateTime.now();
+    switch(trend) {
 
-    List newList = list.where((entry) => DateTime.parse(dfFilter.format(DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000)).toString())
-        .isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
-        .toList();
+      case "week": {
+        newList = list.where((entry) => DateTime.parse(dfFilter.format(DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000)).toString())
+            .isAfter(DateTime(now.year, now.month, now.day).subtract(Duration(days: 6)))  )
+            .toList();
+        averageValue = newList.fold(0, (current, entry) => current + entry["weight"]) / 7.0;
+      }
+      break;
 
-    double averageValue = newList.fold(0, (current, entry) => current + entry["weight"]) / 7.0;
+      //for month data
+      default: {
+        newList = list.where((entry)=> DateTime.fromMillisecondsSinceEpoch(entry["time"] * 1000).month == DateTime.now().month )
+            .toList();
+        averageValue = newList.fold(0, (current, entry) => current + entry["weight"]) / 31.0;
+      }
+    }
 
     setState(() {
       if (type == "general") {

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -15,57 +15,66 @@ class SettingsPageState extends State<SettingsPage>{
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: Styles.MainStatsPageHeader("Settings", FontWeight.bold, Colors.black),
-      body: SettingsList(
+
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.green,
+      ),
+
+
+      home: Scaffold(
         backgroundColor: Colors.white,
-        sections: [
-          SettingsSection(
-            title: 'Account',
-            tiles: [
-              SettingsTile(
-                title: 'Change Password ',
-                leading: Icon(Icons.lock_outlined),
-                onPressed: (BuildContext context) {},
-              ),
+        appBar: Styles.MainStatsPageHeader("Settings", FontWeight.bold, Colors.black),
+        body: SettingsList(
+          lightBackgroundColor: Colors.white,
+          sections: [
+            SettingsSection(
+              title: 'Account',
+              tiles: [
+                SettingsTile(
+                  title: 'Change Password ',
+                  leading: Icon(Icons.lock_outlined),
+                  onPressed: (BuildContext context) {},
+                ),
 
-              SettingsTile(
-                title: 'Sign Out',
-                leading: Icon(Icons.logout),
-                onPressed: (BuildContext context) {},
-              ),
-            ],
-          ),
+                SettingsTile(
+                  title: 'Sign Out',
+                  leading: Icon(Icons.logout),
+                  onPressed: (BuildContext context) {},
+                ),
+              ],
+            ),
+            
+            SettingsSection(
+              title: 'Miscellaneous ',
+              tiles: [
 
-          SettingsSection(
-            title: 'Miscellaneous ',
-            tiles: [
+                SettingsTile(
+                  title: 'About Us',
+                  leading: Icon(Icons.info_outlined),
+                  onPressed: (BuildContext context) {},
+                ),
 
-              SettingsTile(
-                title: 'About Us',
-                leading: Icon(Icons.info_outlined),
-                onPressed: (BuildContext context) {},
-              ),
-
-              SettingsTile(
-                title: 'Contact Us',
-                leading: Icon(Icons.mail_outlined),
-                onPressed: (BuildContext context) {},
-              ),
-              SettingsTile(
-                title: 'Terms of Services',
-                leading: Icon(Icons.article_outlined),
-                onPressed: (BuildContext context) {},
-              ),
-              SettingsTile(
-                title: 'Licences',
-                leading: Icon(Icons.copyright),
-                onPressed: (BuildContext context) {},
-              ),
-            ],
-          ),
-        ],
+                SettingsTile(
+                  title: 'Contact Us',
+                  leading: Icon(Icons.mail_outlined),
+                  onPressed: (BuildContext context) {},
+                ),
+                SettingsTile(
+                  title: 'Terms of Services',
+                  leading: Icon(Icons.article_outlined),
+                  onPressed: (BuildContext context) {},
+                ),
+                SettingsTile(
+                  title: 'Licences',
+                  leading: Icon(Icons.copyright),
+                  onPressed: (BuildContext context) {},
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "0.1.3+1"
   firebase_core:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
@@ -282,6 +282,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.6"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -317,6 +324,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2+3"
   quiver:
     dependency: transitive
     description:
@@ -436,4 +450,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.16.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   flutter:
     sdk: flutter
   cloud_firestore:
+  provider:
+  firebase_core:
   firebase_auth: 0.15.2
   firebase_storage:
   charts_flutter:


### PR DESCRIPTION
Overall
- amended userID information retrieval for all pages to be centralised at wasteless-data.dart

Leaderboard
- added new default dropdown menu of "Select Type" and "Select Trend"
- term "General" replaced with "Trash". Edited body code to reflect changes accordingly
- "NO DATA" displayed if no data is present
- alternating colours for list depending on type of waste selected

History
- added new default dropdown menu of "Select Type" and "Select Trend"
- term "General" replaced with "Trash". Edited body code to reflect changes accordingly
- "NO DATA" displayed if no data is present
- alternating colours for list depending on type of waste selected

Personal Stats
- Feature added: title toggles between Trash and Recyclables when tapped onto

- add Week averages to be wrapped in respective coloured box

- add Month averages to be wrapped in respective coloured box

- line annotation on bar graphs that changes position based on above type and trend selected implemented.

Settings
- changed the sub headers to green
